### PR TITLE
It solve in get cache key problem when body json has different order in N requests

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -33,5 +33,25 @@ describe('cache', () => {
       });
       expect(result).toEqual('771798e93f4fbad36b4c89cd88d3752383224caf8e585661dc174feb25939f75');
     });
+
+    it('returns a same hash uniquely representing the params when body has different order', async () => {
+      let params = {
+        method: 'POST',
+        path: '/v1/completions',
+        authHeader: null,
+        body: '{"key1":"1","key2":"2"}',
+      };
+      let result = await getCacheKey(params);
+      expect(result).toEqual('91b1af0c3f20778905ab588460bcb1d14b4621445f32fd871d7fe23056142923');
+
+      params = {
+        method: 'POST',
+        path: '/v1/completions',
+        authHeader: null,
+        body: '{"key2":"2","key1":"1"}',
+      };
+      result = await getCacheKey(params);
+      expect(result).toEqual('91b1af0c3f20778905ab588460bcb1d14b4621445f32fd871d7fe23056142923');
+    });
   });
 });

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -12,11 +12,11 @@ describe('cache', () => {
         method: 'POST',
         path: '/v1/completions',
         authHeader: 'api-key-!',
-        body: '{ "ok": true }',
+        body: '{"ok":true}',
       };
       const result = await getCacheKey(params);
       expect(utils.objectHash).toHaveBeenCalledWith(params);
-      expect(result).toEqual('1a97143b720b3d82cf93a34a5a02c61de1492b18d813f4f1859251eef1a738be');
+      expect(result).toEqual('de8cb85a7a697a5ee1458b31857c4db1c94760b2a14681052170bed55bf6db1b');
     });
 
     it('removes null or empty values', async () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -12,8 +12,16 @@ export const getCacheKey = async (props: GetCacheKeyProps): Promise<string> => {
   // https://stackoverflow.com/a/40924449
   const propsWithoutUndefined = Object.keys(props).reduce((acc, key) => {
     const _acc: Record<string, any> = acc;
-    const propValue = (props as any)[key];
-    if (propValue != null && propValue !== '') {
+    let propValue = (props as any)[key];
+    if (key === 'body' && propValue !== '') {
+      try {
+        const body = JSON.parse(propValue);
+        propValue = JSON.stringify(body, Object.keys(body).sort());
+      } catch (_error) {
+        propValue = '';
+      }
+    }
+    if (propValue !== null && propValue !== '') {
       _acc[key] = propValue;
     }
     return _acc;


### PR DESCRIPTION
The mobile apps usually transform json to string in random order and the cache key was different in each similar request

This is a solution for reuse always the same cache key and  keep saving money :) 